### PR TITLE
Handle deserialization for fixed-size nodes

### DIFF
--- a/public/templates/macros.njk
+++ b/public/templates/macros.njk
@@ -38,10 +38,10 @@
 
 {# Recursive Borsh Reader, responsible for handling collections and any nested levels #}
 {% macro borshReader(field) %}  
-  {{ recursiveReader(field.nesting, field.baseType, field.isStruct, field.size, field.format) }}
+  {{ recursiveReader(field.nesting, field.baseType, field.isStruct, field.size) }}
 {% endmacro %}
 
-{% macro recursiveReader(depth, baseType, isStruct, size, format) %}
+{% macro recursiveReader(depth, baseType, isStruct, size) %}
   {% if depth > 5 %}
     // ERROR: Nesting depth exceeds supported limit (5)
     throw Exception('Nesting depth exceeds supported limit(5)');
@@ -49,88 +49,26 @@
     {% if isStruct %}
       {{ baseType }}Borsh.fromBorsh(reader)
     {% else %}
-      {{ baseTypeReader(baseType, false, size, format) }}
+      {{ baseTypeReader(baseType, false, size) }}
     {% endif %}
   {% else %}
-      {% if size is defined %}
-        reader.readFixedArray({{size}}, () {
-      {% else %}
-        reader.readArray(() {
-      {% endif %}
+    reader.readArray(() {
       {% if isStruct %}
         // item is a struct, call fromBorsh per item
         return {{ baseType }}Borsh.fromBorsh(reader);
       {% else %}
-        return {{ recursiveReader(depth - 1, baseType, false, size, format) }};
+        return {{ recursiveReader(depth - 1, baseType, false, size) }};
       {% endif %}
-      })
-  {% endif %}
-{% endmacro %}
-
-{% macro intFormatUtil(format, isWrite, varName='value') %}
-  {% if format == 'u8' %}
-    {% if isWrite %}
-      writer.writeU8({{ varName }})
-    {% else %}
-      reader.readU8()
-    {% endif %}
-  {% elif format == 'i8' %}
-    {% if isWrite %}
-      writer.writeI8({{ varName }})
-    {% else %}
-      reader.readI8()
-    {% endif %}
-  {% elif format == 'u16' %}
-    {% if isWrite %}
-      writer.writeU16({{ varName }})
-    {% else %}
-      reader.readU16()
-    {% endif %}
-  {% elif format == 'i16' %}
-    {% if isWrite %}
-      writer.writeI16({{ varName }})
-    {% else %}
-      reader.readI16()
-    {% endif %}
-  {% elif format == 'u32' %}
-    {% if isWrite %}
-      writer.writeU32({{ varName }})
-    {% else %}
-      reader.readU32()
-    {% endif %}
-  {% elif format == 'i32' %}
-    {% if isWrite %}
-      writer.writeI32({{ varName }})
-    {% else %}
-      reader.readI32()
-    {% endif %}
-  {% elif format == 'u64' %}
-    {% if isWrite %}
-      writer.writeU64({{ varName }})
-    {% else %}
-      reader.readU64()
-    {% endif %}
-  {% elif format == 'i64' %}
-    {% if isWrite %}
-      writer.writeI64({{ varName }})
-    {% else %}
-      reader.readI64()
-    {% endif %}
-  {% elif format == 'u128' or format == 'i128' %}
-    {% if isWrite %}
-      writer.writeBigInt({{ varName }})
-    {% else %}
-      reader.readBigInt()
-    {% endif %}
-  {% else %}
-    throw Exception('Unsupported number format: {{ format }}');
+    })
   {% endif %}
 {% endmacro %}
 
 {# Reader for the base types (no nesting) #}
-{% macro baseTypeReader(baseType, isStruct, size, format) %}
-  {% if baseType == 'int' or baseType == 'BigInt' %}
-    {{ intFormatUtil(format, false) }}
+{% macro baseTypeReader(baseType, isStruct, size) %}
+  {% if baseType == 'int' %}
+    reader.readInt()
+  {% elif baseType == 'BigInt' %}
+    reader.readBigInt()
   {% elif baseType == 'String' %}
     reader.readString()
   {% elif baseType == 'Uint8List' %}
@@ -162,10 +100,10 @@
 {# Recursive Borsh Writer, responsible to handle nested type of collections  #}
 {% macro borshWriter(field, overrideFieldName="") %}
   {% set name = overrideFieldName if overrideFieldName else field.name %}
-  {{ recursiveWriter(name, field.nesting, field.baseType, field.isStruct, field.size, field.format) }}
+  {{ recursiveWriter(name, field.nesting, field.baseType, field.isStruct, field.size) }}
 {% endmacro %}
 
-{% macro recursiveWriter(varName, depth, baseType, isStruct, size, format) %}
+{% macro recursiveWriter(varName, depth, baseType, isStruct, size) %}
   {% if depth > 5 %}
     // ERROR: Nesting depth exceeds supported limit (5)
     throw Exception('Nesting depth exceeds supported limit(5)');
@@ -174,35 +112,26 @@
       {{ varName }}.toBorsh(writer);
     {% else %}
     {# TODO: I have problem here because of these recursions i put ';' twice because twice is iterated here first trough writeArray and on the recursion i go inside here and i put ';' again #}
-      {{ baseTypeWriter(baseType, varName, size, format) }};
+      {{ baseTypeWriter(baseType, varName, size) }};
     {% endif %}
   {% else %}
-    {% if size is defined %}
-      writer.writeFixedArray<{{ baseType }}>({{size}}, {{ varName }}, ({{ baseType }} item) {
-    {% else %}
-      writer.writeArray<{{ baseType }}>({{ varName }}, ({{ baseType }} item) {
-    {% endif %}
-    {% if isStruct %}
-      // Each item is a struct
-      item.toBorsh(writer);
-    {% else %}
-      {{ recursiveWriter("item", depth - 1, baseType, false, size, format) }};
-    {% endif %}
-  });
+    writer.writeArray<{{ baseType }}>({{ varName }}, ({{ baseType }} item) {
+      {% if isStruct %}
+        // Each item is a struct
+        item.toBorsh(writer);
+      {% else %}
+        {{ recursiveWriter("item", depth - 1, baseType, false, size) }};
+      {% endif %}
+    });
   {% endif %}
 {% endmacro %}
 
-   {# writer.writeFixedArray<Ed25519HDPublicKey>(
-    pubkey_array,
-    (Ed25519HDPublicKey item) {
-      writer.writePubkey(Uint8List.fromList(item.bytes));
-    },
-    2 // <-- specify the fixed length here
-  ); #}
 {# Base Writer, no nested types inside #}
-{% macro baseTypeWriter(baseType, varName, size, format) %}
-  {% if baseType == 'int' or baseType == 'BigInt' %}
-    {{ intFormatUtil(format, true, varName) }}
+{% macro baseTypeWriter(baseType, varName, size) %}
+  {% if baseType == 'int' %}
+    writer.writeInt({{ varName }})
+  {% elif baseType == 'BigInt' %}
+    writer.writeBigInt({{ varName }})
   {% elif baseType == 'String' %}
     writer.writeString({{ varName }})
   {% elif baseType == 'Uint8List' %}

--- a/public/templates/pages/definedTypesPage.njk
+++ b/public/templates/pages/definedTypesPage.njk
@@ -23,13 +23,6 @@ extension {{ definedType.name | pascalCase }}Borsh on {{ definedType.name | pasc
     {# Initial idx value used to track which field from fields collection is reached #}
     {% set startIdx = 0 %} 
     {% for variant in definedType.type.variants %}
-      {% if variant.kind == 'enumEmptyVariantTypeNode' %}
-        {# The enum is empty but i still need to specify the Variant Index in Borsh Serialization #}
-        if (this is {{ variant.name | pascalCase }}) {
-          writer.writeU8({{ loop.index0 }}); // Variant index expected by Borsh
-        }
-      {% endif %}
-
       {% if variant.kind != 'enumEmptyVariantTypeNode' %}
         if (this is {{ variant.name | pascalCase }}) {
           {# Count of fields that this Variant has #}
@@ -40,7 +33,6 @@ extension {{ definedType.name | pascalCase }}Borsh on {{ definedType.name | pasc
           %}
 
           {% set indices = range(startIdx, startIdx + count) %}  {# Index range for this enum Variant's fields #}
-          writer.writeU8({{ loop.index0 }}); // Variant index expected by Bors
           final v = this as {{ variant.name | pascalCase }};
           
           {% for i in indices %}

--- a/public/templates/pages/errorsPage.njk
+++ b/public/templates/pages/errorsPage.njk
@@ -14,19 +14,6 @@ class {{ program.name | pascalCase }}ErrorCode {
 
 /// Base class for all {{ program.name | pascalCase }} program errors.
 abstract class {{ program.name | pascalCase }}Error extends Error {
-
-  /// Utility: Extracts and maps a Solana error string to an {{program.name | pascalCase }}Error, or null if not found.
-  static {{program.name | pascalCase}}Error? fromSolanaErrorString(Object error) {
-    final errorString = error.toString();
-    final match = RegExp(r'custom program error: 0x([0-9a-fA-F]+)').firstMatch(errorString);
-    if (match != null) {
-      final codeHex = match.group(1);
-      final code = int.parse(codeHex!, radix: 16);
-      return {{ program.name | pascalCase }}Error.fromCode(code);
-    }
-    return null;
-  }
-
   /// The numerical error code.
   final int code;
   

--- a/public/templates/pages/sharedPage.njk
+++ b/public/templates/pages/sharedPage.njk
@@ -46,8 +46,7 @@ class BinaryReader {
   /// Reads a single public key (32 raw bytes, no prefix).
   Uint8List readPubkey() {
     final length = 32;
-    final bytes =
-        Uint8List.view(_data.buffer, _data.offsetInBytes + _offset, length);
+    final bytes = Uint8List.view(_data.buffer, _data.offsetInBytes + _offset, length);
     _offset += length;
     return bytes;
   }
@@ -281,11 +280,6 @@ class BinaryReader {
     );
   }
 
-  // Reads a fixed-length array of generic items.
-  List<T> readFixedArray<T>(int length, T Function() itemReader) {
-    return List.generate(length, (_) => itemReader());
-  }
-
   /// Reads a variable-length array of generic items.
   List<T> readArray<T>(T Function() itemReader) {
     final count = readU32();
@@ -430,10 +424,7 @@ class BinaryWriter {
 
   /// Writes a signed 64-bit integer.
   void writeI64(BigInt value) {
-    var v = value.toSigned(64);
-    for (int i = 0; i < 8; i++) {
-      _bytes.add(((v >> (8 * i)) & BigInt.from(0xFF)).toInt());
-    }
+    writeU64(value & (BigInt.one << 64) - BigInt.one);
   }
 
   /// Writes a string.
@@ -575,22 +566,6 @@ class BinaryWriter {
   void writeBytes(Uint8List value) {
     writeU32(value.length);
     _bytes.addAll(value);
-  }
-
-    // Reads a fixed-length array of generic items.
-  // List<T> readFixedArray<T>(int length, T Function() itemReader) {
-  //   return List.generate(length, (_) => itemReader());
-  // }
-
-
-  void writeFixedArray<T>(int length, List<T> items, void Function(T) itemWriter) {
-    final count = length ?? items.length;
-    if (items.length < count) {
-      throw ArgumentError('items length (${items.length}) is less than fixed array length ($count)');
-    }
-    for (int i = 0; i < count; i++) {
-      itemWriter(items[i]);
-    }
   }
 
   /// Writes a variable-length array of generic items.


### PR DESCRIPTION
# What

When in the client the user needs to deserialize(read) a field, when he reads the blockchain state for a certain account from his anchor deployed program.The dart-renderer should handle fixed-sized fields(arrays, etc..) in the `readBorsh` methods because it needs to know how much bytes(how long is the field) to take from the buffer to show the correct value. 

I tried to handle that in a more abstract way, specifically from the visitors, but I struggled a lot there because the visitor passes recursively and I needed to have all that information in TypeManifest instead of me modifying a specific node. That is why I decided to keep using Aleksandar’s approach for using regex and comments, which i have extended.