### PR TITLE
Dart numbers borsh support

### DIFF
--- a/public/templates/macros.njk
+++ b/public/templates/macros.njk
@@ -38,10 +38,10 @@
 
 {# Recursive Borsh Reader, responsible for handling collections and any nested levels #}
 {% macro borshReader(field) %}  
-  {{ recursiveReader(field.nesting, field.baseType, field.isStruct, field.size) }}
+  {{ recursiveReader(field.nesting, field.baseType, field.isStruct, field.size, field.format) }}
 {% endmacro %}
 
-{% macro recursiveReader(depth, baseType, isStruct, size) %}
+{% macro recursiveReader(depth, baseType, isStruct, size, format) %}
   {% if depth > 5 %}
     // ERROR: Nesting depth exceeds supported limit (5)
     throw Exception('Nesting depth exceeds supported limit(5)');
@@ -49,7 +49,7 @@
     {% if isStruct %}
       {{ baseType }}Borsh.fromBorsh(reader)
     {% else %}
-      {{ baseTypeReader(baseType, false, size) }}
+      {{ baseTypeReader(baseType, false, size, format) }}
     {% endif %}
   {% else %}
     reader.readArray(() {
@@ -57,18 +57,76 @@
         // item is a struct, call fromBorsh per item
         return {{ baseType }}Borsh.fromBorsh(reader);
       {% else %}
-        return {{ recursiveReader(depth - 1, baseType, false, size) }};
+        return {{ recursiveReader(depth - 1, baseType, false, size, format) }};
       {% endif %}
     })
   {% endif %}
 {% endmacro %}
 
+{% macro intFormatUtil(format, isWrite, varName='value') %}
+  {% if format == 'u8' %}
+    {% if isWrite %}
+      writer.writeU8({{ varName }})
+    {% else %}
+      reader.readU8()
+    {% endif %}
+  {% elif format == 'i8' %}
+    {% if isWrite %}
+      writer.writeI8({{ varName }})
+    {% else %}
+      reader.readI8()
+    {% endif %}
+  {% elif format == 'u16' %}
+    {% if isWrite %}
+      writer.writeU16({{ varName }})
+    {% else %}
+      reader.readU16()
+    {% endif %}
+  {% elif format == 'i16' %}
+    {% if isWrite %}
+      writer.writeI16({{ varName }})
+    {% else %}
+      reader.readI16()
+    {% endif %}
+  {% elif format == 'u32' %}
+    {% if isWrite %}
+      writer.writeU32({{ varName }})
+    {% else %}
+      reader.readU32()
+    {% endif %}
+  {% elif format == 'i32' %}
+    {% if isWrite %}
+      writer.writeI32({{ varName }})
+    {% else %}
+      reader.readI32()
+    {% endif %}
+  {% elif format == 'u64' %}
+    {% if isWrite %}
+      writer.writeU64({{ varName }})
+    {% else %}
+      reader.readU64()
+    {% endif %}
+  {% elif format == 'i64' %}
+    {% if isWrite %}
+      writer.writeI64({{ varName }})
+    {% else %}
+      reader.readI64()
+    {% endif %}
+  {% elif format == 'u128' or format == 'i128' %}
+    {% if isWrite %}
+      writer.writeBigInt({{ varName }})
+    {% else %}
+      reader.readBigInt()
+    {% endif %}
+  {% else %}
+    throw Exception('Unsupported number format: {{ format }}');
+  {% endif %}
+{% endmacro %}
+
 {# Reader for the base types (no nesting) #}
-{% macro baseTypeReader(baseType, isStruct, size) %}
-  {% if baseType == 'int' %}
-    reader.readInt()
-  {% elif baseType == 'BigInt' %}
-    reader.readBigInt()
+{% macro baseTypeReader(baseType, isStruct, size, format) %}
+  {% if baseType == 'int' or baseType == 'BigInt' %}
+    {{ intFormatUtil(format, false) }}
   {% elif baseType == 'String' %}
     reader.readString()
   {% elif baseType == 'Uint8List' %}
@@ -100,10 +158,10 @@
 {# Recursive Borsh Writer, responsible to handle nested type of collections  #}
 {% macro borshWriter(field, overrideFieldName="") %}
   {% set name = overrideFieldName if overrideFieldName else field.name %}
-  {{ recursiveWriter(name, field.nesting, field.baseType, field.isStruct, field.size) }}
+  {{ recursiveWriter(name, field.nesting, field.baseType, field.isStruct, field.size, field.format) }}
 {% endmacro %}
 
-{% macro recursiveWriter(varName, depth, baseType, isStruct, size) %}
+{% macro recursiveWriter(varName, depth, baseType, isStruct, size, format) %}
   {% if depth > 5 %}
     // ERROR: Nesting depth exceeds supported limit (5)
     throw Exception('Nesting depth exceeds supported limit(5)');
@@ -112,7 +170,7 @@
       {{ varName }}.toBorsh(writer);
     {% else %}
     {# TODO: I have problem here because of these recursions i put ';' twice because twice is iterated here first trough writeArray and on the recursion i go inside here and i put ';' again #}
-      {{ baseTypeWriter(baseType, varName, size) }};
+      {{ baseTypeWriter(baseType, varName, size, format) }};
     {% endif %}
   {% else %}
     writer.writeArray<{{ baseType }}>({{ varName }}, ({{ baseType }} item) {
@@ -120,18 +178,16 @@
         // Each item is a struct
         item.toBorsh(writer);
       {% else %}
-        {{ recursiveWriter("item", depth - 1, baseType, false, size) }};
+        {{ recursiveWriter("item", depth - 1, baseType, false, size, format) }};
       {% endif %}
     });
   {% endif %}
 {% endmacro %}
 
 {# Base Writer, no nested types inside #}
-{% macro baseTypeWriter(baseType, varName, size) %}
-  {% if baseType == 'int' %}
-    writer.writeInt({{ varName }})
-  {% elif baseType == 'BigInt' %}
-    writer.writeBigInt({{ varName }})
+{% macro baseTypeWriter(baseType, varName, size, format) %}
+  {% if baseType == 'int' or baseType == 'BigInt' %}
+    {{ intFormatUtil(format, true, varName) }}
   {% elif baseType == 'String' %}
     writer.writeString({{ varName }})
   {% elif baseType == 'Uint8List' %}

--- a/src/getTypeManifestVisitor.ts
+++ b/src/getTypeManifestVisitor.ts
@@ -239,30 +239,70 @@ export function getTypeManifestVisitor(options: TypeManifestOptions) {
                 visitNumberType(numberType: NumberTypeNode): TypeManifest {
                     switch (numberType.format) {
                         case 'u8':
-                        case 'u16':
-                        case 'u32':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'int /* type: u8 */',
+                            };
                         case 'i8':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'int /* type: i8 */',
+                            };
+                        case 'u16':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'int /* type: u16 */',
+                            };
                         case 'i16':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'int /* type: i16 */',
+                            };
+                        case 'u32':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'int /* type: u32 */',
+                            };
                         case 'i32':
                             return {
                                 imports: new ImportMap(),
                                 nestedStructs: [],
-                                type: 'int',
+                                type: 'int /* type: i32 */',
                             };
                         case 'u64':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'BigInt /* type: u64 */',
+                            };
                         case 'i64':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'BigInt /* type: i64 */',
+                            };
                         case 'u128':
+                            return {
+                                imports: new ImportMap(),
+                                nestedStructs: [],
+                                type: 'BigInt /* type: u128 */',
+                            };
                         case 'i128':
                             return {
                                 imports: new ImportMap(),
                                 nestedStructs: [],
-                                type: 'BigInt',
+                                type: 'BigInt /* type: i128 */',
                             };
                         case 'shortU16':
                             return {
                                 imports: new ImportMap(),
                                 nestedStructs: [],
-                                type: 'int',
+                                type: 'int /* type: shortU16 */',
                             };
                         default:
                             throw new Error(`Unknown number format: ${numberType.format}`);


### PR DESCRIPTION
# What

I found that in dart language there are no integer types like `u8`, `u16`, `i32`, ...., instead dart supports only `int` and `BigInt` so i needed a way to store the actually rust type in order to provide correct borsh methods to serialize/deserialize the exact bytes that the anchor program expects for a certain number type.

## Key Changes
- Added format support in readers/writers (intFormatUtil) for all numeric types.
- Extended recursive reader/writer macros to handle both size and format.
- Updated TypeManifestField to include format and fixed-size info.
- Improved regex parsing in extractFieldsFromTypeManifest to capture type and length from comments.
- Updated getTypeManifestVisitor to annotate numeric types with inline /* type: ... */ comments.
