### PR TITLE
Derive the programID from programs module

### DIFF
--- a/src/visitors/getRenderMapVisitor.ts
+++ b/src/visitors/getRenderMapVisitor.ts
@@ -107,6 +107,7 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                         }
 
                         const pdaName = camelCase(account.name);
+                        const programNode = findProgramNodeFromPath(stack.getPath('instructionNode'));
 
                         // Avoid duplicate PDA files for the same account name
                         if (!pdaRenderMaps.has(pdaName)) {
@@ -115,7 +116,8 @@ export function getRenderMapVisitor(options: GetRenderMapOptions) {
                                 account.defaultValue.pda,
                                 account.defaultValue.seeds,
                                 renderScope.nameApi,
-                                findProgramNodeFromPath(stack.getPath('instructionNode'))?.publicKey,
+                                programNode?.publicKey,
+                                programNode?.name,
                                 asPage,
                             );
                             if (pdaFile) {


### PR DESCRIPTION
All fallback logic is preserved. If the programId cannot be derived from the module, the public key is used directly as before.